### PR TITLE
set host-ip either by using the mac gateway IP, or by the normal method

### DIFF
--- a/docker/psibase-contributor.Dockerfile
+++ b/docker/psibase-contributor.Dockerfile
@@ -79,7 +79,7 @@ export PS1="\u@\h \W\[\\033[32m\\]\\$(parse_git_branch)\\[\\033[00m\\] $ "\n\
  \n\
 alias ll="ls -alF"\n\
 alias ls="ls --color=auto"\n\
-export HOST_IP=$(ip route | awk "/default/ { print \$3 }") \
+export HOST_IP=${MAC_GW_IP:-$(ip route | awk "/default/ { print \$3 }")} \
 ' >> /root/.bashrc
 
 # Caches


### PR DESCRIPTION
This is the best thing I can come up with for now that improves our situation.

The HOST_IP variable will either contain the value of [the mac IP address set by psibase-contributor](https://github.com/gofractally/psibase-contributor/pull/29), or it will discover the host gateway ip through the normal method (known to work on linux/windows host OS).